### PR TITLE
Update __init__.py

### DIFF
--- a/SpaceFlow/__init__.py
+++ b/SpaceFlow/__init__.py
@@ -1,0 +1,42 @@
+from warnings import warn, catch_warnings, simplefilter
+from .umap_ import UMAP
+
+try:
+    with catch_warnings():
+        simplefilter("ignore")
+        from .parametric_umap import ParametricUMAP, load_ParametricUMAP
+except ImportError:
+    warn(
+        "Tensorflow not installed; ParametricUMAP will be unavailable",
+        category=ImportWarning,
+    )
+
+    # Add a dummy class to raise an error
+    class ParametricUMAP(object):
+        def __init__(self, **kwds):
+            warn(
+                """The umap.parametric_umap package requires Tensorflow > 2.0 to be installed.
+            You can install Tensorflow at https://www.tensorflow.org/install
+
+            or you can install the CPU version of Tensorflow using 
+
+            pip install umap-learn[parametric_umap]
+
+            """
+            )
+            raise ImportError(
+                "umap.parametric_umap requires Tensorflow >= 2.0"
+            ) from None
+
+
+from .aligned_umap import AlignedUMAP
+
+# Workaround: https://github.com/numba/numba/issues/3341
+import numba
+
+from importlib_metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("umap-learn")
+except PackageNotFoundError:
+    __version__ = "0.5-dev"


### PR DESCRIPTION
When I ran the code, I encountered the following error:

ModuleNotFoundError: No module named 'importlib.metadata'.

This happened because the correct module name is importlib_metadata. To fix the issue, I updated the _init_.py file to use importlib_metadata instead.

However, I noticed that the _init_.py file on the GitHub repository was empty. Since I’m not an expert and wasn’t sure why, I copied the content of the _init_.py file from the installed SpaceFlow package located at:

~/anaconda3/envs/spaceflow_env/lib/python3.7/site-packages/umap/__init__.py.

This resolved the issue.